### PR TITLE
feat: selectionAdd에서 searchPanel 및 selectionModal간의 api 연동 구현 (#47)

### DIFF
--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import nullPlaceImage from '../assets/images/null_place.png'; // 폴백 이미지 import
-import SelectionModal from './Modal/SelectionModal'; // SelectionModal 임포트 확인
 
 // 애니메이션 keyframe 정의
 const fadeIn = keyframes`
@@ -283,10 +282,10 @@ const AddButton = styled.button<{ isComplete?: boolean }>`
 
 // 로딩 및 에러 메시지 스타일
 const MessageText = styled.p`
-  text-align: center;
-  color: #555;
-  padding: 20px;
-  font-size: 14px;
+    text-align: center;
+    color: #555;
+    padding: 20px;
+    font-size: 14px;
 `;
 
 // SearchPanelProps 인터페이스 업데이트
@@ -297,25 +296,11 @@ interface SearchPanelProps {
     searchTerm: string;
     onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     onSearch: () => void;
-    searchResults: { id: number; name: string; address: string; imageUrl?: string; coordinates?: { lat: number; lng: number } }[];
+    searchResults: { id: number; name: string; address: string; imageUrl?: string; }[];
     onAddPlace: (place: { id: number; name: string }) => void;
     isLoading?: boolean; // 로딩 상태 prop 추가
     error?: string | null; // 에러 메시지 prop 추가
-}
-
-// SelectionModal에 전달될 데이터 타입 (TravelItem과 유사하게)
-// 이 타입은 SelectionModal 컴포넌트의 selectedTravelItem prop 타입과 호환되어야 합니다.
-interface ModalDisplayData {
-    attractionId?: number;
-    restaurantId?: number;
-    imageUrl: string;
-    name: string;
-    title: string; 
-    address?: string;
-    // SelectionModal에서 사용하지 않는다면 description은 없어도 됨
-    // description?: string; 
-    latitude?: number;
-    longitude?: number;
+    onItemSelect: (id: number, type: 'travel' | 'restaurant') => void; // 상세 정보 로드를 위한 콜백 추가
 }
 
 const SearchPanel: React.FC<SearchPanelProps> = ({
@@ -328,50 +313,20 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
     searchResults,
     onAddPlace,
     isLoading,
-    error
+    error,
+    onItemSelect
 }) => {
     const Container = type === 'travel' ? TravelSearchContainer : RestaurantSearchContainer;
     const titleText = type === 'travel' ? '여행지 검색' : '음식점 검색';
     const placeholder = type === 'travel' ? '여행지를 검색하세요' : '음식점을 검색하세요';
-    
-    const [isModalOpen, setIsModalOpen] = useState(false);
-    const [selectedPlace, setSelectedPlace] = useState<ModalDisplayData | null>(null);
     
     // 새로운 상태: 현재 검색어에 대한 검색 시도 여부
     const [searchAttempted, setSearchAttempted] = useState(false);
         
     const handlePlaceClick = (place: { 
         id: number; 
-        name: string; 
-        address: string; 
-        imageUrl?: string; 
-        coordinates?: { lat: number; lng: number } 
     }) => {
-        const placeDataForModal: ModalDisplayData = {
-            // type에 따라 attractionId 또는 restaurantId 설정
-            ...(type === 'travel' ? { attractionId: place.id } : { restaurantId: place.id }),
-            name: place.name,
-            title: place.name, // SelectionModal에서 title을 사용하므로 name과 동일하게 설정
-            imageUrl: place.imageUrl || nullPlaceImage, // imageUrl 사용, 없으면 nullPlaceImage
-            address: place.address,
-            // description은 ModalDisplayData에 포함시키지 않음 (SelectionModal이 사용 안 함 가정)
-            latitude: place.coordinates?.lat,
-            longitude: place.coordinates?.lng,
-        };
-        setSelectedPlace(placeDataForModal);
-        setIsModalOpen(true);
-    };
-    
-    const handleSelectPlace = () => {
-        if (selectedPlace) {
-            // onAddPlace는 id와 name만 필요로 함
-            // selectedPlace에서 id를 가져올 때 attractionId 또는 restaurantId 확인
-            const id = selectedPlace.attractionId || selectedPlace.restaurantId;
-            if (id !== undefined) { // id가 유효한지 확인
-                onAddPlace({ id: id, name: selectedPlace.name });
-            }
-        }
-        setIsModalOpen(false);
+        onItemSelect(place.id, type); // 부모에게 id와 type 전달
     };
 
     const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
@@ -425,7 +380,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
                     {!isLoading && !error && searchResults.map(place => (
                         <SearchResultItem 
                             key={place.id} 
-                            onClick={() => handlePlaceClick(place)} 
+                            onClick={() => handlePlaceClick(place)}
                             type="button"
                         >
                             <PlaceImage>
@@ -453,15 +408,6 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
                     ))}
                 </SearchResults>
             </Container>
-            
-            {selectedPlace && (
-                <SelectionModal 
-                    isOpen={isModalOpen}
-                    onClose={() => setIsModalOpen(false)}
-                    selectedTravelItem={selectedPlace}
-                    onSelect={handleSelectPlace}
-                />
-            )}
         </>
     );
 };

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled, { keyframes } from 'styled-components';
-import travel_img3 from '../assets/images/travel_img3.jpg';
-import SelectionModal from './Modal/SelectionModal';
+import nullPlaceImage from '../assets/images/null_place.png'; // 폴백 이미지 import
+import SelectionModal from './Modal/SelectionModal'; // SelectionModal 임포트 확인
 
 // 애니메이션 keyframe 정의
 const fadeIn = keyframes`
@@ -26,7 +26,6 @@ const fadeOut = keyframes`
     }
 `;
 
-// 슬라이드 인 애니메이션 수정
 const slideInLeft = keyframes`
     from {
         opacity: 0;
@@ -49,7 +48,6 @@ const slideInRight = keyframes`
     }
 `;
 
-// 슬라이드 아웃 애니메이션 수정
 const slideOutLeft = keyframes`
     from {
         opacity: 1;
@@ -283,6 +281,15 @@ const AddButton = styled.button<{ isComplete?: boolean }>`
     }
 `;
 
+// 로딩 및 에러 메시지 스타일
+const MessageText = styled.p`
+  text-align: center;
+  color: #555;
+  padding: 20px;
+  font-size: 14px;
+`;
+
+// SearchPanelProps 인터페이스 업데이트
 interface SearchPanelProps {
     type: 'travel' | 'restaurant';
     isClosing: boolean;
@@ -292,6 +299,23 @@ interface SearchPanelProps {
     onSearch: () => void;
     searchResults: { id: number; name: string; address: string; imageUrl?: string; coordinates?: { lat: number; lng: number } }[];
     onAddPlace: (place: { id: number; name: string }) => void;
+    isLoading?: boolean; // 로딩 상태 prop 추가
+    error?: string | null; // 에러 메시지 prop 추가
+}
+
+// SelectionModal에 전달될 데이터 타입 (TravelItem과 유사하게)
+// 이 타입은 SelectionModal 컴포넌트의 selectedTravelItem prop 타입과 호환되어야 합니다.
+interface ModalDisplayData {
+    attractionId?: number;
+    restaurantId?: number;
+    imageUrl: string;
+    name: string;
+    title: string; 
+    address?: string;
+    // SelectionModal에서 사용하지 않는다면 description은 없어도 됨
+    // description?: string; 
+    latitude?: number;
+    longitude?: number;
 }
 
 const SearchPanel: React.FC<SearchPanelProps> = ({
@@ -302,27 +326,20 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
     onSearchChange,
     onSearch,
     searchResults,
-    onAddPlace
+    onAddPlace,
+    isLoading,
+    error
 }) => {
     const Container = type === 'travel' ? TravelSearchContainer : RestaurantSearchContainer;
-    const title = type === 'travel' ? '여행지 검색' : '음식점 검색';
+    const titleText = type === 'travel' ? '여행지 검색' : '음식점 검색';
     const placeholder = type === 'travel' ? '여행지를 검색하세요' : '음식점을 검색하세요';
     
-    // 모달 상태 관리
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const [selectedPlace, setSelectedPlace] = useState<null | {
-        id: number;
-        title: string;
-        image: string;
-        description: string;
-        location?: string;
-        coordinates?: { lat: number; lng: number }
-    }>(null);
+    const [selectedPlace, setSelectedPlace] = useState<ModalDisplayData | null>(null);
     
-    // 기본 이미지 URL
-    const defaultImage = travel_img3;
-    
-    // 장소 선택 처리
+    // 새로운 상태: 현재 검색어에 대한 검색 시도 여부
+    const [searchAttempted, setSearchAttempted] = useState(false);
+        
     const handlePlaceClick = (place: { 
         id: number; 
         name: string; 
@@ -330,71 +347,123 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
         imageUrl?: string; 
         coordinates?: { lat: number; lng: number } 
     }) => {
-        setSelectedPlace({
-            id: place.id,
-            title: place.name,
-            image: place.imageUrl || defaultImage,
-            description: `${place.name}는 ${place.address}에 위치한 ${type === 'travel' ? '관광지' : '음식점'}입니다.`,
-            location: place.address,
-            coordinates: place.coordinates
-        });
+        const placeDataForModal: ModalDisplayData = {
+            // type에 따라 attractionId 또는 restaurantId 설정
+            ...(type === 'travel' ? { attractionId: place.id } : { restaurantId: place.id }),
+            name: place.name,
+            title: place.name, // SelectionModal에서 title을 사용하므로 name과 동일하게 설정
+            imageUrl: place.imageUrl || nullPlaceImage, // imageUrl 사용, 없으면 nullPlaceImage
+            address: place.address,
+            // description은 ModalDisplayData에 포함시키지 않음 (SelectionModal이 사용 안 함 가정)
+            latitude: place.coordinates?.lat,
+            longitude: place.coordinates?.lng,
+        };
+        setSelectedPlace(placeDataForModal);
         setIsModalOpen(true);
     };
     
-    // 모달에서 장소 선택 시 처리
     const handleSelectPlace = () => {
         if (selectedPlace) {
-            onAddPlace({ id: selectedPlace.id, name: selectedPlace.title });
+            // onAddPlace는 id와 name만 필요로 함
+            // selectedPlace에서 id를 가져올 때 attractionId 또는 restaurantId 확인
+            const id = selectedPlace.attractionId || selectedPlace.restaurantId;
+            if (id !== undefined) { // id가 유효한지 확인
+                onAddPlace({ id: id, name: selectedPlace.name });
+            }
         }
         setIsModalOpen(false);
+    };
+
+    const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+        e.currentTarget.src = nullPlaceImage;
+    };
+
+    // 검색어 입력창 변경 시 호출될 내부 핸들러
+    const handleInternalSearchTermChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        onSearchChange(e); // 부모의 searchTerm 상태 업데이트
+        setSearchAttempted(false); // 검색어가 변경되었으므로, 검색 시도 상태 초기화
+    };
+
+    // 검색 버튼 클릭 또는 Enter 시 호출될 내부 핸들러
+    const handleInternalSearch = () => {
+        if (searchTerm.trim() !== '') {
+            setSearchAttempted(true); // 유효한 검색어로 검색 시도
+        } else {
+            setSearchAttempted(false); // 빈 검색어로는 시도하지 않음 (또는 결과 없음으로 간주 안함)
+            // 부모의 onSearch는 빈 검색어일 때 알아서 결과를 비우거나 할 것임
+        }
+        onSearch(); // 부모의 검색 실행 로직 호출
     };
 
     return (
         <>
             <Container isClosing={isClosing}>
-                <SearchTitle>{title}</SearchTitle>
+                <SearchTitle>{titleText}</SearchTitle>
                 <SearchForm>
                     <SearchInput 
                         type="text" 
                         placeholder={placeholder} 
                         value={searchTerm}
-                        onChange={onSearchChange}
-                        onKeyPress={(e) => e.key === 'Enter' && onSearch()}
+                        onChange={handleInternalSearchTermChange}
+                        onKeyPress={(e) => {
+                            if (e.key === 'Enter') {
+                                handleInternalSearch();
+                            }
+                        }}
+                        disabled={isLoading} 
                     />
-                    <SearchButton onClick={onSearch}>검색</SearchButton>
+                    <SearchButton onClick={handleInternalSearch} disabled={isLoading}>
+                        검색
+                    </SearchButton>
                 </SearchForm>
                 <SearchResults>
-                    {searchResults.map(place => (
+                    {isLoading && <MessageText>검색 중입니다...</MessageText>}
+                    {error && <MessageText>오류: {error}</MessageText>}
+                    {searchAttempted && !isLoading && !error && searchResults.length === 0 && searchTerm.trim() !== '' && (
+                        <MessageText>검색 결과가 없습니다. 다른 키워드로 시도해 보세요.</MessageText>
+                    )}
+                    {!isLoading && !error && searchResults.map(place => (
                         <SearchResultItem 
                             key={place.id} 
                             onClick={() => handlePlaceClick(place)} 
                             type="button"
                         >
                             <PlaceImage>
-                                <Image src={place.imageUrl || defaultImage} alt={place.name} />
+                                <Image 
+                                    src={place.imageUrl || nullPlaceImage} 
+                                    alt={place.name} 
+                                    onError={handleImageError}
+                                />
                             </PlaceImage>
                             <PlaceInfo>
                                 <PlaceName>{place.name}</PlaceName>
                                 <PlaceAddress>{place.address}</PlaceAddress>
                             </PlaceInfo>
-                            <AddButton onClick={(e) => {
-                                e.stopPropagation();
-                                onAddPlace(place);
-                            }} isComplete={isComplete}>선택</AddButton>
+                            <AddButton 
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onAddPlace({ id: place.id, name: place.name });
+                                }} 
+                                isComplete={isComplete}
+                                disabled={isComplete}
+                            >
+                                선택
+                            </AddButton>
                         </SearchResultItem>
                     ))}
                 </SearchResults>
             </Container>
             
-            {/* 선택한 장소 정보 모달 */}
-            <SelectionModal 
-                isOpen={isModalOpen}
-                onClose={() => setIsModalOpen(false)}
-                selectedTravelItem={selectedPlace}
-                onSelect={handleSelectPlace}
-            />
+            {selectedPlace && (
+                <SelectionModal 
+                    isOpen={isModalOpen}
+                    onClose={() => setIsModalOpen(false)}
+                    selectedTravelItem={selectedPlace}
+                    onSelect={handleSelectPlace}
+                />
+            )}
         </>
     );
 };
 
-export default SearchPanel; 
+export default SearchPanel;

--- a/src/pages/Selection/selectionAdd.tsx
+++ b/src/pages/Selection/selectionAdd.tsx
@@ -6,6 +6,7 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import SearchPanel from '../../components/SearchPanel';
 import SelectionSidebar from '../../components/SelectionSidebar';
 import { authenticatedFetch } from '../../services/api';
+import SelectionModal from '../../components/Modal/SelectionModal';
 
 // 메인 컨테이너 스타일 컴포넌트
 const MainContainer = styled.div`
@@ -59,7 +60,7 @@ interface SelectedPlaceItem {
     title: string;
 }
 
-// API로부터 받는 여행지 검색 결과 항목의 예상 타입
+// 검색 결과로부터 받는 여행지 검색 결과 항목의 예상 타입
 interface ApiSearchAttraction {
     attractionId: number;
     name: string;
@@ -67,7 +68,7 @@ interface ApiSearchAttraction {
     imageUrl?: string;
 }
 
-// API로부터 받는 음식점 검색 결과 항목의 예상 타입 (여행지와 유사할 수 있음)
+// 검색 결과로부터 받는 음식점 검색 결과 항목의 예상 타입
 interface ApiSearchRestaurant {
     restaurantId: number;
     name: string;
@@ -81,6 +82,46 @@ interface SearchResultItem {
     name: string;
     address: string;
     imageUrl?: string;
+}
+
+// 상세 정보 API 응답 (여행지)
+interface ApiAttractionDetail {
+    attractionId: number;
+    name: string;
+    address: string;
+    imageUrl?: string;
+    phone?: string;
+    title?: string;
+    operatingHours?: string;
+    latitude?: number;
+    longitude?: number;
+}
+
+// 상세 정보 API 응답 (음식점)
+interface ApiRestaurantDetail {
+    restaurantId: number;
+    name: string;
+    address: string;
+    imageUrl?: string;
+    phone?: string;
+    title?: string;
+    operatingHours?: string;
+    latitude?: number;
+    longitude?: number;
+}
+
+// SelectionModal에 전달될 데이터 타입
+interface ModalDisplayData {
+    id: number; // 공통 ID
+    type: 'travel' | 'restaurant';
+    name: string;
+    imageUrl?: string;
+    address?: string;
+    phone?: string; 
+    title?: string; 
+    operatingHours?: string;
+    latitude?: number;
+    longitude?: number;
 }
 
 const STORAGE_KEY_DESTINATIONS_PREFIX = 'selectedDestinations_';
@@ -165,6 +206,12 @@ const SelectionAdd: React.FC = () => {
     const [deletingRestaurantId, setDeletingRestaurantId] = useState<number | null>(null);
 
     const [isClosingSearch, setIsClosingSearch] = useState(false);
+
+    // 모달 관련 상태
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [modalData, setModalData] = useState<ModalDisplayData | null>(null);
+    const [isLoadingModalData, setIsLoadingModalData] = useState(false);
+    const [modalError, setModalError] = useState<string | null>(null);
 
     // 두 선택이 모두 완료되었을 때 로딩 시작
     useEffect(() => {
@@ -317,6 +364,7 @@ const SelectionAdd: React.FC = () => {
             }
             const data = await response.json();
             if (data.isSuccess && data.result && Array.isArray(data.result.attractions)) {
+                // ApiSearchAttraction에서 SearchResultItem으로 매핑 시, SearchPanel의 props에 맞게 필드 조정
                 const formattedResults: SearchResultItem[] = data.result.attractions.map((item: ApiSearchAttraction) => ({
                     id: item.attractionId,
                     name: item.name,
@@ -326,7 +374,6 @@ const SelectionAdd: React.FC = () => {
                 setTravelSearchResults(formattedResults);
             } else {
                 setTravelSearchResults([]);
-                // setTravelSearchError(data.message || 'No results or incorrect format');
             }
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : '여행지 검색 중 오류가 발생했습니다.';
@@ -340,8 +387,8 @@ const SelectionAdd: React.FC = () => {
     // 음식점 검색 버튼 클릭 핸들러
     const handleRestaurantSearch = async () => {
         if (!restaurantSearchTerm.trim()) {
-            setRestaurantSearchResults([]); // 검색어가 없으면 결과 초기화
-            setRestaurantSearchError(null); // 에러도 초기화
+            setRestaurantSearchResults([]);
+            setRestaurantSearchError(null);
             return;
         }
         setIsSearchingRestaurant(true);
@@ -364,18 +411,16 @@ const SelectionAdd: React.FC = () => {
             const data = await response.json();
 
             if (data.isSuccess && data.result && Array.isArray(data.result.restaurants)) {
+                 // ApiSearchRestaurant에서 SearchResultItem으로 매핑 시, SearchPanel의 props에 맞게 필드 조정
                 const formattedResults: SearchResultItem[] = data.result.restaurants.map((restaurant: ApiSearchRestaurant) => ({
-                    id: restaurant.restaurantId, // API 응답에 따라 restaurant.id일 수도 있음
+                    id: restaurant.restaurantId,
                     name: restaurant.name,
                     address: restaurant.address,
                     imageUrl: restaurant.imageUrl,
                 }));
                 setRestaurantSearchResults(formattedResults);
             } else {
-                console.warn('Restaurant search API response format is incorrect or no results:', data.message);
                 setRestaurantSearchResults([]); 
-                // 필요하다면 data.message를 setRestaurantSearchError로 사용자에게 표시
-                // setRestaurantSearchError(data.message || '검색 결과가 없거나 형식이 맞지 않습니다.');
             }
         } catch (err) {
             console.error("Error fetching restaurant search results:", err);
@@ -419,6 +464,67 @@ const SelectionAdd: React.FC = () => {
         }
     };
 
+    // 상세 정보 로드 및 모달 표시 함수
+    const handleLoadAndShowPlaceDetails = async (id: number, type: 'travel' | 'restaurant') => {
+        setIsLoadingModalData(true);
+        setModalError(null);
+        setModalData(null);
+
+        try {
+            const endpoint = type === 'travel' 
+                ? `/api/trip-plans/attractions/${id}` 
+                : `/api/trip-plans/restaurants/${id}`;
+            const response = await authenticatedFetch(endpoint);
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ message: 'Failed to fetch details and parse error response.' }));
+                throw new Error(errorData.message || `Failed to fetch ${type} details`);
+            }
+            
+            const result = await response.json();
+            // API 응답 구조가 { isSuccess: boolean, result: DetailObject } 형태라고 가정
+            if (result.isSuccess && result.result) {
+                const detailData = result.result;
+                const commonModalData: ModalDisplayData = {
+                    id: type === 'travel' ? (detailData as ApiAttractionDetail).attractionId : (detailData as ApiRestaurantDetail).restaurantId,
+                    type: type,
+                    name: detailData.name,
+                    imageUrl: detailData.imageUrl,
+                    address: detailData.address,
+                    phone: detailData.phone, // phone 필드 사용
+                    title: detailData.title,
+                    operatingHours: detailData.operatingHours,
+                    latitude: detailData.latitude,
+                    longitude: detailData.longitude,
+                };
+                setModalData(commonModalData);
+                setIsModalOpen(true);
+            } else {
+                throw new Error(`Could not retrieve details for the selected ${type}.`);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : '상세 정보를 불러오는 중 오류가 발생했습니다.';
+            setModalError(errorMessage);
+            // 에러 발생 시에도 모달을 열어 에러 메시지를 보여줄 수 있음 (선택 사항)
+            // setIsModalOpen(true); 
+        } finally {
+            setIsLoadingModalData(false);
+        }
+    };
+
+    // 모달에서 장소 "추가하기" 버튼 클릭 시 핸들러
+    const handleAddPlaceFromModal = () => {
+        if (modalData) {
+            if (modalData.type === 'travel') {
+                handleAddTravel({ id: modalData.id, name: modalData.name });
+            } else {
+                handleAddRestaurant({ id: modalData.id, name: modalData.name });
+            }
+        }
+        setIsModalOpen(false); // 모달 닫기
+        setModalData(null); // 모달 데이터 초기화
+    };
+
     return (
         <>
             <MainContainer>
@@ -434,6 +540,7 @@ const SelectionAdd: React.FC = () => {
                         onAddPlace={handleAddTravel}
                         isLoading={isSearchingTravel}
                         error={travelSearchError}
+                        onItemSelect={handleLoadAndShowPlaceDetails}
                     />
                 )}
 
@@ -477,12 +584,47 @@ const SelectionAdd: React.FC = () => {
                         onAddPlace={handleAddRestaurant}
                         isLoading={isSearchingRestaurant}
                         error={restaurantSearchError}
+                        onItemSelect={handleLoadAndShowPlaceDetails}
                     />
                 )}
             </MainContainer>
             
             {isLoading && (
                 <LoadingSpinner message="가이드가 최적의 여행 계획을 작성 중입니다..." />
+            )}
+
+            {/* SelectionModal 렌더링 */}
+            {isModalOpen && modalData && (
+                <SelectionModal
+                    isOpen={isModalOpen}
+                    onClose={() => {
+                        setIsModalOpen(false);
+                        setModalData(null);
+                        setModalError(null);
+                    }}
+                    selectedTravelItem={{
+                        // SelectionModal의 TravelItem이 id, name, imageUrl, title, address, operatingHours, latitude, longitude, phone 등을 직접 받을 수 있도록 가정
+                        ...(modalData.type === 'travel' ? { attractionId: modalData.id } : { restaurantId: modalData.id }),
+                        name: modalData.name,
+                        imageUrl: modalData.imageUrl || '', // null일 경우 빈 문자열 또는 폴백 이미지 경로
+                        title: modalData.title || '', // title이 undefined일 경우 name 또는 빈 문자열 사용
+                        address: modalData.address,
+                        operatingHours: modalData.operatingHours,
+                        latitude: modalData.latitude,
+                        longitude: modalData.longitude,
+                        phoneNumber: modalData.phone, // phone을 phoneNumber로 변경
+                    }}
+                    onSelect={handleAddPlaceFromModal}
+                    // isLoading, error 등의 prop도 SelectionModal에 필요하다면 추가
+                />
+            )}
+            {/* 모달 로딩 또는 에러 상태를 표시할 수 있습니다. */}
+            {isLoadingModalData && <LoadingSpinner message="상세 정보 로딩 중..." />}
+            {!isLoadingModalData && modalError && !isModalOpen && (
+                <div style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', background: 'white', padding: '20px', borderRadius: '8px', boxShadow: '0 0 10px rgba(0,0,0,0.2)', zIndex: 1001 }}>
+                    <p>오류: {modalError}</p>
+                    <button onClick={() => setModalError(null)}>닫기</button>
+                </div>
             )}
         </>
     );

--- a/src/pages/Selection/selectionAdd.tsx
+++ b/src/pages/Selection/selectionAdd.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect} from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import Modal from 'react-modal';
@@ -57,6 +57,30 @@ Modal.setAppElement('#root'); // 모달을 위한 설정
 interface SelectedPlaceItem {
     id: number;
     title: string;
+}
+
+// API로부터 받는 여행지 검색 결과 항목의 예상 타입
+interface ApiSearchAttraction {
+    attractionId: number;
+    name: string;
+    address: string;
+    imageUrl?: string;
+}
+
+// API로부터 받는 음식점 검색 결과 항목의 예상 타입 (여행지와 유사할 수 있음)
+interface ApiSearchRestaurant {
+    restaurantId: number;
+    name: string;
+    address: string;
+    imageUrl?: string;
+}
+
+// SearchPanel에 전달될 공통 검색 결과 항목 타입
+interface SearchResultItem {
+    id: number;
+    name: string;
+    address: string;
+    imageUrl?: string;
 }
 
 const STORAGE_KEY_DESTINATIONS_PREFIX = 'selectedDestinations_';
@@ -119,16 +143,15 @@ const SelectionAdd: React.FC = () => {
     const [showTravelSearch, setShowTravelSearch] = useState(false);
     const [showRestaurantSearch, setShowRestaurantSearch] = useState(false);
     
-    // 검색 결과를 위한 상태 관리 (API 연동 시 변경 필요)
-    const [travelSearchResults] = useState([
-        { id: 101, name: '부산타워', address: '부산 중구 용두산길 37-55' },
-        { id: 102, name: '해동용궁사', address: '부산 기장군 기장읍 기장해안로 86' },
-    ]);
+    // 여행지 검색 결과 상태
+    const [travelSearchResults, setTravelSearchResults] = useState<SearchResultItem[]>([]);
+    const [isSearchingTravel, setIsSearchingTravel] = useState(false);
+    const [travelSearchError, setTravelSearchError] = useState<string | null>(null);
     
-    const [restaurantSearchResults] = useState([
-        { id: 201, name: '자갈치 시장', address: '부산 중구 자갈치해안로 52' },
-        { id: 202, name: '가야밀면', address: '부산 진구 가야대로 507' },
-    ]);
+    // 음식점 검색 결과 상태 (API로부터 받아옴)
+    const [restaurantSearchResults, setRestaurantSearchResults] = useState<SearchResultItem[]>([]); // 빈 배열로 초기화
+    const [isSearchingRestaurant, setIsSearchingRestaurant] = useState(false);
+    const [restaurantSearchError, setRestaurantSearchError] = useState<string | null>(null);
 
     // 선택 완료 상태 관리
     const [isTravelComplete, setIsTravelComplete] = useState(false);
@@ -273,13 +296,95 @@ const SelectionAdd: React.FC = () => {
         setRestaurantSearchTerm(e.target.value);
     };
 
-    // 검색 버튼 클릭 핸들러 (실제 검색 로직 필요)
-    const handleTravelSearch = () => {
-        console.log('여행지 검색:', travelSearchTerm);
+    // 여행지 검색 버튼 클릭 핸들러
+    const handleTravelSearch = async () => {
+        if (!travelSearchTerm.trim()) {
+            setTravelSearchResults([]);
+            setTravelSearchError(null);
+            return;
+        }
+        setIsSearchingTravel(true);
+        setTravelSearchError(null);
+        try {
+            const response = await authenticatedFetch(`/api/trip-plans/attractions/search?keyword=${encodeURIComponent(travelSearchTerm)}`);
+            if (!response.ok) {
+                let errorMsg = `HTTP error! status: ${response.status}`;
+                try {
+                    const errorData = await response.json();
+                    errorMsg = errorData.message || errorMsg;
+                } catch { /* ignore */ }
+                throw new Error(errorMsg);
+            }
+            const data = await response.json();
+            if (data.isSuccess && data.result && Array.isArray(data.result.attractions)) {
+                const formattedResults: SearchResultItem[] = data.result.attractions.map((item: ApiSearchAttraction) => ({
+                    id: item.attractionId,
+                    name: item.name,
+                    address: item.address,
+                    imageUrl: item.imageUrl,
+                }));
+                setTravelSearchResults(formattedResults);
+            } else {
+                setTravelSearchResults([]);
+                // setTravelSearchError(data.message || 'No results or incorrect format');
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : '여행지 검색 중 오류가 발생했습니다.';
+            setTravelSearchError(errorMessage);
+            setTravelSearchResults([]);
+        } finally {
+            setIsSearchingTravel(false);
+        }
     };
 
-    const handleRestaurantSearch = () => {
-        console.log('음식점 검색:', restaurantSearchTerm);
+    // 음식점 검색 버튼 클릭 핸들러
+    const handleRestaurantSearch = async () => {
+        if (!restaurantSearchTerm.trim()) {
+            setRestaurantSearchResults([]); // 검색어가 없으면 결과 초기화
+            setRestaurantSearchError(null); // 에러도 초기화
+            return;
+        }
+        setIsSearchingRestaurant(true);
+        setRestaurantSearchError(null);
+        try {
+            const response = await authenticatedFetch(`/api/trip-plans/restaurants/search?keyword=${encodeURIComponent(restaurantSearchTerm)}`, {
+                method: 'GET',
+            });
+
+            if (!response.ok) {
+                let errorMsg = `HTTP error! status: ${response.status}`;
+                try {
+                    const errorData = await response.json();
+                    errorMsg = errorData.message || errorMsg;
+                } catch {
+                    console.log('Error response body is not valid JSON for restaurant search.');
+                }
+                throw new Error(errorMsg);
+            }
+            const data = await response.json();
+
+            if (data.isSuccess && data.result && Array.isArray(data.result.restaurants)) {
+                const formattedResults: SearchResultItem[] = data.result.restaurants.map((restaurant: ApiSearchRestaurant) => ({
+                    id: restaurant.restaurantId, // API 응답에 따라 restaurant.id일 수도 있음
+                    name: restaurant.name,
+                    address: restaurant.address,
+                    imageUrl: restaurant.imageUrl,
+                }));
+                setRestaurantSearchResults(formattedResults);
+            } else {
+                console.warn('Restaurant search API response format is incorrect or no results:', data.message);
+                setRestaurantSearchResults([]); 
+                // 필요하다면 data.message를 setRestaurantSearchError로 사용자에게 표시
+                // setRestaurantSearchError(data.message || '검색 결과가 없거나 형식이 맞지 않습니다.');
+            }
+        } catch (err) {
+            console.error("Error fetching restaurant search results:", err);
+            const errorMessage = err instanceof Error ? err.message : '음식점 검색 중 오류가 발생했습니다.';
+            setRestaurantSearchError(errorMessage);
+            setRestaurantSearchResults([]);
+        } finally {
+            setIsSearchingRestaurant(false);
+        }
     };
 
     // 여행지/음식점 추가 버튼 핸들러
@@ -327,6 +432,8 @@ const SelectionAdd: React.FC = () => {
                         onSearch={handleTravelSearch}
                         searchResults={travelSearchResults}
                         onAddPlace={handleAddTravel}
+                        isLoading={isSearchingTravel}
+                        error={travelSearchError}
                     />
                 )}
 
@@ -368,6 +475,8 @@ const SelectionAdd: React.FC = () => {
                         onSearch={handleRestaurantSearch}
                         searchResults={restaurantSearchResults}
                         onAddPlace={handleAddRestaurant}
+                        isLoading={isSearchingRestaurant}
+                        error={restaurantSearchError}
                     />
                 )}
             </MainContainer>


### PR DESCRIPTION
### #️⃣ 연관된 이슈 
> 관련 이슈번호를 적어주세요
ex) #이슈번호

- #47 

### 📝 작업 내용 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- **`selectionAdd`에서 `searchPanel`과 `selectionModal`간의 api 연동 구현**
- **`selectionAdd`가 중심 역할을 하며 모든 api GET 요청으로 데이터를 받아옴**
- api Flow
  1. `searchPanel`에 검색한 키워드 기반으로 `selectionAdd`가 데이터를 받아옴
  2. 받아온 데이터를 기반으로 `searchPanel`에게 필요한 데이터를 넘겨줌
  3. `searchPanel`에서 선택한 세부 장소 정보를 위해 `selectionAdd`에게 해당 장소의 Id값
  4. 해당 id를 기반으로 `selectionAdd`가 `selectionModal`에 띄울 데이터를 받아옴
 

### 💬 리뷰 요청사항 (선택)
> 리뷰어가 특별히 확인해주었으면 하는 부분이 있다면 작성해 주세요.

- 
