### PR TITLE
feat: 일정 조회 페이지 반응형 UI 구현 (Agentic-AI-Busan#90)

### DIFF
--- a/src/pages/Mypage/myGuidePage.tsx
+++ b/src/pages/Mypage/myGuidePage.tsx
@@ -415,6 +415,26 @@ const MyGuidePage: React.FC = () => {
     const [editingTitle, setEditingTitle] = useState("");
 
     const [tripPlans, setTripPlans] = useState<TripPlan[]>([]);
+    const [itemsPerPage, setItemsPerPage] = useState(2);
+
+    useEffect(() => {
+        const updateItemsPerPage = () => {
+            const windowHeight = window.innerHeight;
+            const topPadding = 60 + 20 + 40;
+            const availableHeight = windowHeight - topPadding - 100;
+
+            const cardHeight = 250;
+            const cardGap = 24;
+
+            let count = Math.floor((availableHeight + cardGap) / (cardHeight + cardGap));
+            if (window.innerWidth <= 768) count = 1;
+
+            setItemsPerPage(Math.max(1, count));
+        };
+        updateItemsPerPage();
+        window.addEventListener('resize', updateItemsPerPage);
+        return () => window.removeEventListener('resize', updateItemsPerPage);
+    }, []);
 
     useEffect(() => {
         const fetchTripPlans = async () => {
@@ -430,7 +450,6 @@ const MyGuidePage: React.FC = () => {
         fetchTripPlans();
     }, []);
     
-    const itemsPerPage = 2;
     const totalPages = Math.ceil((tripPlans?.length || 0) / itemsPerPage);
     
     // 현재 페이지에 표시할 아이템들


### PR DESCRIPTION
### #️⃣ 연관된 이슈 
> 관련 이슈번호를 적어주세요
ex) #이슈번호

- #90

### 📝 작업 내용 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 일정 조회 페이지 반응형 UI 구현 (화면 크기에 따라 최대 4개까지 한페이지에 표시되도록 수정)
