### PR TITLE
일정 편집 페이지 일정 제목 입력 로직 구현 (#93)

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -101,19 +101,6 @@ const RememberMe = styled.label`
   }
 `
 
-const ForgotLink = styled.a`
-  color: #3498db;
-  font-size: 14px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: color 0.2s ease;
-  
-  &:hover {
-    color: #2980b9;
-    text-decoration: underline;
-  }
-`
-
 const SubmitButton = styled.button`
   width: 100%;
   height: 50px;
@@ -245,7 +232,6 @@ export default function LoginForm() {
               />
               아이디 저장
             </RememberMe>
-            <ForgotLink href="/find-password">비밀번호 찾기</ForgotLink>
           </FormRow>
         </InputGroup>
 

--- a/src/components/Modal/TitleInputModal.tsx
+++ b/src/components/Modal/TitleInputModal.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface TitleInputModalProps {
+    isOpen: boolean;
+    title?: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onConfirm: () => void;
+    onClose: () => void;
+    error?: string;
+}
+
+const ModalOverlay = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0,0,0,0.3);
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+const ModalBox = styled.div`
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    padding: 32px 28px 24px 28px;
+    min-width: 340px;
+    max-width: 90vw;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+`;
+
+const ModalTitle = styled.h3`
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 18px;
+    color: #222;
+    text-align: center;
+`;
+
+const Input = styled.input`
+    width: 100%;
+    padding: 12px 14px;
+    border: 1.5px solid #e1e1e1;
+    border-radius: 8px;
+    font-size: 16px;
+    margin-bottom: 16px;
+    box-sizing: border-box;
+    &:focus {
+        border-color: #3498db;
+        outline: none;
+    }
+`;
+
+const ErrorText = styled.div`
+    color: #e74c3c;
+    font-size: 14px;
+    margin-bottom: 10px;
+    text-align: center;
+`;
+
+const ButtonRow = styled.div`
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+`;
+
+const ModalButton = styled.button`
+    padding: 10px 22px;
+    border-radius: 8px;
+    border: none;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    background: #3498db;
+    color: #fff;
+    transition: background 0.2s;
+    &:hover {
+        background: #2980b9;
+    }
+    &:first-child {
+        background: #f1f5f9;
+        color: #333;
+        border: 1px solid #e1e1e1;
+        &:hover {
+            background: #e2e8f0;
+        }
+    }
+`;
+
+const TitleInputModal: React.FC<TitleInputModalProps> = ({
+    isOpen, title = '일정 제목 입력', value, onChange, onConfirm, onClose, error
+}) => {
+    if (!isOpen) return null;
+    return (
+        <ModalOverlay>
+            <ModalBox>
+                <ModalTitle>{title}</ModalTitle>
+                <Input
+                    type="text"
+                    value={value}
+                    onChange={onChange}
+                    placeholder="일정 제목을 입력하세요"
+                    maxLength={30}
+                    autoFocus
+                />
+                {error && <ErrorText>{error}</ErrorText>}
+                <ButtonRow>
+                    <ModalButton type="button" onClick={onClose}>취소</ModalButton>
+                    <ModalButton type="button" onClick={onConfirm}>확인</ModalButton>
+                </ButtonRow>
+            </ModalBox>
+        </ModalOverlay>
+    );
+};
+
+export default TitleInputModal; 

--- a/src/pages/LoginSingup/authPage.tsx
+++ b/src/pages/LoginSingup/authPage.tsx
@@ -4,6 +4,7 @@ import styled, { keyframes } from "styled-components"
 import LoginForm from "../../components/LoginForm"
 import SignupForm from "../../components/SignUpForm"
 import mainImage from "../../assets/images/main_image.png"
+import logo from "../../assets/images/logo.svg"
 
 // Content fade animations
 const fadeX = keyframes`
@@ -90,7 +91,7 @@ const SwitchPanel = styled.div<{ $isLogin: boolean }>`
 `
 
 const SwitchLogo = styled.img`
-  max-width: 30px;
+  max-width: 60px;
   position: absolute;
   margin: 1.5em;
   filter: grayscale(1) brightness(3);
@@ -197,7 +198,7 @@ const FormPanel = styled.div`
 `
 
 const FormLogo = styled.img`
-  max-width: 30px;
+  max-width: 60px;
   position: absolute;
   margin: 1.5em;
 `
@@ -259,7 +260,7 @@ export default function AuthPage() {
       <SignContainer>
         {/* Switch Panel (Changes sides) with Background Image */}
         <SwitchPanel $isLogin={isLogin}>
-          <SwitchLogo src="/images/t_logo.png" alt="Logo" />
+          <SwitchLogo src={logo} alt="Logo" />
           <Group>
             <TextGroup>
               <SignContent $isLogin={isLogin}>
@@ -282,7 +283,7 @@ export default function AuthPage() {
 
         {/* Form Panel */}
         <FormPanel>
-          <FormLogo src="/images/t_logo.png" alt="Logo" />
+          <FormLogo src={logo} alt="Logo" />
 
           {/* Render only the active form */}
           <FormSignIn $isVisible={isLogin}>

--- a/src/pages/SchduleEditing/editingPage.tsx
+++ b/src/pages/SchduleEditing/editingPage.tsx
@@ -14,7 +14,8 @@ import SearchModal, { Place as OriginalPlaceFromSearch } from '../../components/
 import DeleteModal from '../../components/Modal/DeleteModal';
 import SaveModal from '../../components/Modal/SaveModal';
 import SelectionModal from '../../components/Modal/SelectionModal';
-import { authenticatedFetch } from '../../services/api';
+import TitleInputModal from '../../components/Modal/TitleInputModal';
+import { authenticatedFetch, getUserTripPlans } from '../../services/api';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import nullPlaceImage from '../../assets/images/null_place.png';
 
@@ -99,6 +100,18 @@ interface TravelItemForSelection {
     phoneNumber?: string;
 }
 
+interface TripPlan {
+    city: string;
+    daydiff: number;
+    endDate: string;
+    imageUrl: string;
+    memo: string;
+    startDate: string;
+    tripPlanId: number;
+    tripPlanName: string;
+    tripPlanStatus: string;
+}
+
 const EditingPage = () => {
     const navigate = useNavigate();
     const location = useLocation();
@@ -118,6 +131,8 @@ const EditingPage = () => {
     });
 
     const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
+    const [isTitleModalOpen, setIsTitleModalOpen] = useState(false);
+    const [tripTitle, setTripTitle] = useState('');
     const [selectedDayIndex, setSelectedDayIndex] = useState<number | null>(null);
     const [selectedPlaceType, setSelectedPlaceType] = useState<'ATTRACTION' | 'RESTAURANT' | null>(null);
 
@@ -289,6 +304,16 @@ const EditingPage = () => {
             });
     };
 
+    const fetchTripTitle = async () => {
+        const response = await getUserTripPlans();
+        if (response && Array.isArray(response.tripPlans) && response.tripPlans.length > 0) {
+            const found = response.tripPlans.find((plan: TripPlan) => plan.tripPlanId === tripPlansId);
+            if (found) {
+                setTripTitle(found.tripPlanName);
+            }
+        }
+    }
+
     useEffect(() => {
         if (!tripPlansId) {
           setError('여행 계획 ID가 없습니다. 이전 페이지로 돌아가 다시 시작해주세요.');
@@ -320,6 +345,8 @@ const EditingPage = () => {
         if (localTransportation) {
             setTripInfo(prev => ({ ...prev, transportation: localTransportation }));
         }
+
+        fetchTripTitle();
         
         authenticatedFetch(`/api/trip-plans/${tripPlansId}`)
             .then(response => {
@@ -836,12 +863,36 @@ const EditingPage = () => {
         } finally {
             setIsLoading(false);
             setIsSaveModalOpen(false);
+            if (tripTitle === '여행 계획') {
+                setIsTitleModalOpen(true);
+            } else {
+                navigate('/myGuide');
+            }
         }
     };
 
     const deletePlace = (dayIndex: number, placeId: number) => {
       setPlaceToDelete({ dayIndex, placeId });
       setIsDeleteModalOpen(true);
+    };
+
+    const handleTitleInputConfirm = async () => {
+        try {
+            const response = await authenticatedFetch(`/api/trip-plans/${tripPlansId}/title?title=${tripTitle}`, {
+                method: 'PUT',
+            });
+            if (!response.ok) {
+                throw new Error('일정 제목 변경에 실패했습니다.');
+            }
+            const result = await response.json();
+            console.log('일정 제목 변경 성공:', result);
+            alert('일정 제목이 성공적으로 변경되었습니다.');
+        } catch (err) {
+            console.error('일정 저장 API 호출 중 오류 발생:', err);
+        } finally {
+            setIsTitleModalOpen(false);
+            navigate('/myGuide');
+        }
     };
 
     const handleDelete = () => {
@@ -1110,6 +1161,14 @@ const EditingPage = () => {
             isOpen={isSaveModalOpen}
             onClose={() => setIsSaveModalOpen(false)}
             onSave={handleSave}
+            title="일정 저장"
+        />
+        <TitleInputModal
+            isOpen={isTitleModalOpen}
+            value={tripTitle === "여행 계획" ? "" : tripTitle}
+            onChange={e => setTripTitle(e.target.value)}
+            onClose={() => setIsTitleModalOpen(false)}
+            onConfirm={handleTitleInputConfirm}
             title="일정 저장"
         />
         </PageLayout>


### PR DESCRIPTION
### #️⃣ 연관된 이슈 
> 관련 이슈번호를 적어주세요
ex) #이슈번호

- #93 

### 📝 작업 내용 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 일정 제목 입력 모달 UI 구현
- 일정 편집 페이지에서 저장 시 일정 제목을 입력 받는 로직 구현
- 일정 제목 입력 API 연동

- (추가) 로그인 페이지 로고 적용
- (추가) 로그인 페이지 비밀번호 찾기 기능 삭제
